### PR TITLE
When resolving error messages, search full chain of error codes

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/spring4/extension/function/bindingresult/GetAllErrorsFunction.java
+++ b/src/main/java/com/mitchellbosecke/pebble/spring4/extension/function/bindingresult/GetAllErrorsFunction.java
@@ -51,8 +51,7 @@ public class GetAllErrorsFunction extends BaseBindingResultFunction {
     List<String> errorMessages = new ArrayList<>();
     if (bindingResult != null) {
       for (ObjectError error : bindingResult.getAllErrors()) {
-        String msg = this.messageSource.getMessage(error.getCode(), error.getArguments(),
-                error.getDefaultMessage(), locale);
+        String msg = this.messageSource.getMessage(error, locale);
         errorMessages.add(msg);
       }
     }

--- a/src/main/java/com/mitchellbosecke/pebble/spring4/extension/function/bindingresult/GetFieldErrorsFunction.java
+++ b/src/main/java/com/mitchellbosecke/pebble/spring4/extension/function/bindingresult/GetFieldErrorsFunction.java
@@ -56,8 +56,7 @@ public class GetFieldErrorsFunction extends BaseBindingResultFunction {
     List<String> errorMessages = new ArrayList<>();
     if (bindingResult != null) {
       for (FieldError error : bindingResult.getFieldErrors(field)) {
-        String msg = this.messageSource.getMessage(error.getCode(), error.getArguments(),
-                error.getDefaultMessage(), locale);
+        String msg = this.messageSource.getMessage(error, locale);
         errorMessages.add(msg);
       }
     }


### PR DESCRIPTION
Hi, I have an update I hope you'll consider merging...

Currently `getAllErrors` and `getFieldErrors` functions use the default (last choice) error code when trying to resolve an error message. I updated these Pebble functions to use the overloaded version of `MessageSource.getMessage` that takes a `MessageSourceResolvable` so that error codes are searched in order of preference.

Example:

In a Spring MVC application, a form field for a product price is being bound to a `BigDecimal`. If the user enters an invalid dollar amount, a binding error occurs and `DefaultMessageCodeResolver` creates these four error codes in order of preference...

1. typeMismatch.product.price
2. typeMismatch.price
3. typeMismatch.java.math.BigDecimal
4. typeMismatch

The current implementation chooses the generic, last choice `typeMismatch`, bypassing the preferred error codes, which makes it difficult to add custom error messages to an application.

Thanks.

See [DefaultMessageCodesResolver](http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/validation/DefaultMessageCodesResolver.html) and [MessageSource](http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/MessageSource.html#getMessage-org.springframework.context.MessageSourceResolvable-java.util.Locale-)